### PR TITLE
feat: Add NIP-88 Poll and PollResponse models

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -66,6 +66,8 @@ part 'src/models/video.dart';
 part 'src/models/reporting.dart';
 part 'src/models/calendar_events.dart';
 part 'src/models/voice_message.dart';
+part 'src/models/poll.dart';
+part 'src/models/poll_response.dart';
 
 part 'src/models/nwc.dart';
 part 'src/nwc/nwc_connection.dart';

--- a/lib/src/models/poll.dart
+++ b/lib/src/models/poll.dart
@@ -25,16 +25,11 @@ enum PollType {
 /// Poll represents a poll event (kind 1068) as specified in NIP-88.
 /// Polls allow users to create questions with multiple choice options.
 class Poll extends RegularModel<Poll> {
-  late final BelongsTo<Profile> author;
   late final HasMany<PollResponse> responses;
   late final BelongsTo<Model> targetModel;
 
   Poll.fromMap(super.map, super.ref) : super.fromMap() {
-    // Author relationship (inherited from Model but we set it up here for clarity)
-    author = BelongsTo(
-      ref,
-      RequestFilter<Profile>(authors: {event.pubkey}).toRequest(),
-    );
+    // Note: author relationship is inherited from Model base class
 
     // All responses to this poll
     responses = HasMany(

--- a/lib/src/models/poll.dart
+++ b/lib/src/models/poll.dart
@@ -1,0 +1,228 @@
+part of models;
+
+/// Poll option with ID and label
+class PollOption extends Equatable {
+  final String id;
+  final String label;
+
+  const PollOption({required this.id, required this.label});
+
+  @override
+  List<Object?> get props => [id, label];
+}
+
+/// Poll types as defined in NIP-88
+enum PollType {
+  singlechoice,
+  multiplechoice;
+
+  static PollType fromString(String? value) {
+    if (value == 'multiplechoice') return PollType.multiplechoice;
+    return PollType.singlechoice; // Default per NIP-88
+  }
+}
+
+/// Poll represents a poll event (kind 1068) as specified in NIP-88.
+/// Polls allow users to create questions with multiple choice options.
+class Poll extends RegularModel<Poll> {
+  late final BelongsTo<Profile> author;
+  late final HasMany<PollResponse> responses;
+  late final BelongsTo<Model> targetModel;
+
+  Poll.fromMap(super.map, super.ref) : super.fromMap() {
+    // Author relationship (inherited from Model but we set it up here for clarity)
+    author = BelongsTo(
+      ref,
+      RequestFilter<Profile>(authors: {event.pubkey}).toRequest(),
+    );
+
+    // All responses to this poll
+    responses = HasMany(
+      ref,
+      RequestFilter<PollResponse>(
+        tags: {
+          '#e': {event.id},
+        },
+        kinds: {1018},
+      ).toRequest(),
+    );
+
+    // Target model (what this poll is about - e.g., an App)
+    if (event.containsTag('a')) {
+      targetModel = BelongsTo(
+        ref,
+        Request.fromIds({event.getFirstTagValue('a')!}),
+      );
+    } else if (event.containsTag('A')) {
+      targetModel = BelongsTo(
+        ref,
+        Request.fromIds({event.getFirstTagValue('A')!}),
+      );
+    } else {
+      targetModel = BelongsTo(ref, null);
+    }
+  }
+
+  /// The poll question/label
+  String get content => event.content;
+
+  /// Poll options extracted from option tags
+  List<PollOption> get options {
+    final optionTags = event.getTagValues('option');
+    return optionTags.map((values) {
+      if (values.length >= 2) {
+        return PollOption(id: values[0], label: values[1]);
+      }
+      return null;
+    }).whereType<PollOption>().toList();
+  }
+
+  /// Poll type (singlechoice or multiplechoice)
+  PollType get pollType =>
+      PollType.fromString(event.getFirstTagValue('polltype'));
+
+  /// When the poll ends (optional)
+  DateTime? get endsAt {
+    final timestamp = event.getFirstTagValue('endsAt');
+    if (timestamp == null) return null;
+    final seconds = int.tryParse(timestamp);
+    if (seconds == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(seconds * 1000);
+  }
+
+  /// Whether the poll has expired
+  bool get isExpired {
+    final end = endsAt;
+    if (end == null) return false;
+    return DateTime.now().isAfter(end);
+  }
+
+  /// Suggested relays for responses
+  Set<String> get relays => event.getTagSetValues('relay');
+}
+
+/// Mixin for PartialPoll providing getters/setters
+mixin PartialPollMixin on RegularPartialModel<Poll> {
+  String? get content => event.content.isEmpty ? null : event.content;
+  set content(String? value) => event.content = value ?? '';
+
+  List<PollOption> get options {
+    final optionTags = event.getTagValues('option');
+    return optionTags.map((values) {
+      if (values.length >= 2) {
+        return PollOption(id: values[0], label: values[1]);
+      }
+      return null;
+    }).whereType<PollOption>().toList();
+  }
+
+  void addOption(PollOption option) {
+    event.addTag('option', [option.id, option.label]);
+  }
+
+  void removeOption(String optionId) {
+    event.removeTagWithValue('option', optionId);
+  }
+
+  PollType get pollType =>
+      PollType.fromString(event.getFirstTagValue('polltype'));
+
+  set pollType(PollType value) =>
+      event.setTagValue('polltype', value.name);
+
+  DateTime? get endsAt {
+    final timestamp = event.getFirstTagValue('endsAt');
+    if (timestamp == null) return null;
+    final seconds = int.tryParse(timestamp);
+    if (seconds == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(seconds * 1000);
+  }
+
+  set endsAt(DateTime? value) {
+    if (value == null) {
+      event.removeTagWithValue('endsAt', event.getFirstTagValue('endsAt') ?? '');
+    } else {
+      event.setTagValue(
+        'endsAt',
+        (value.millisecondsSinceEpoch ~/ 1000).toString(),
+      );
+    }
+  }
+
+  void addRelay(String relayUrl) {
+    event.addTag('relay', [relayUrl]);
+  }
+}
+
+/// Create and sign new poll events.
+///
+/// Example usage:
+/// ```dart
+/// final poll = await PartialPoll(
+///   content: 'Which feature should we build next?',
+///   options: [
+///     PollOption(id: 'a', label: 'Dark mode'),
+///     PollOption(id: 'b', label: 'Offline support'),
+///     PollOption(id: 'c', label: 'Push notifications'),
+///   ],
+///   pollType: PollType.singlechoice,
+///   endsAt: DateTime.now().add(Duration(days: 7)),
+///   targetModel: app,
+/// ).signWith(signer);
+/// ```
+class PartialPoll extends RegularPartialModel<Poll> with PartialPollMixin {
+  PartialPoll.fromMap(super.map) : super.fromMap();
+
+  /// Creates a new poll
+  ///
+  /// [content] - The poll question (required)
+  /// [options] - List of poll options (required, at least 2)
+  /// [pollType] - Single or multiple choice (default: singlechoice)
+  /// [endsAt] - When the poll expires (optional)
+  /// [targetModel] - The model this poll is about (e.g., an App)
+  /// [relays] - Suggested relays for responses
+  /// [createdAt] - Optional creation timestamp
+  PartialPoll({
+    required String content,
+    required List<PollOption> options,
+    PollType pollType = PollType.singlechoice,
+    DateTime? endsAt,
+    Model? targetModel,
+    Set<String>? relays,
+    DateTime? createdAt,
+  }) {
+    event.content = content;
+
+    if (createdAt != null) {
+      event.createdAt = createdAt;
+    }
+
+    // Add options
+    for (final option in options) {
+      event.addTag('option', [option.id, option.label]);
+    }
+
+    // Set poll type
+    event.setTagValue('polltype', pollType.name);
+
+    // Set end time if provided
+    if (endsAt != null) {
+      event.setTagValue(
+        'endsAt',
+        (endsAt.millisecondsSinceEpoch ~/ 1000).toString(),
+      );
+    }
+
+    // Link to target model if provided
+    if (targetModel != null) {
+      linkModel(targetModel);
+    }
+
+    // Add relay hints
+    if (relays != null) {
+      for (final relay in relays) {
+        event.addTag('relay', [relay]);
+      }
+    }
+  }
+}

--- a/lib/src/models/poll.dart
+++ b/lib/src/models/poll.dart
@@ -68,10 +68,11 @@ class Poll extends RegularModel<Poll> {
 
   /// Poll options extracted from option tags
   List<PollOption> get options {
-    final optionTags = event.getTagValues('option');
-    return optionTags.map((values) {
-      if (values.length >= 2) {
-        return PollOption(id: values[0], label: values[1]);
+    final optionTags = event.getTagSet('option');
+    return optionTags.map((tag) {
+      // tag is ["option", "id", "label"]
+      if (tag.length >= 3) {
+        return PollOption(id: tag[1], label: tag[2]);
       }
       return null;
     }).whereType<PollOption>().toList();
@@ -107,10 +108,11 @@ mixin PartialPollMixin on RegularPartialModel<Poll> {
   set content(String? value) => event.content = value ?? '';
 
   List<PollOption> get options {
-    final optionTags = event.getTagValues('option');
-    return optionTags.map((values) {
-      if (values.length >= 2) {
-        return PollOption(id: values[0], label: values[1]);
+    final optionTags = event.getTagSet('option');
+    return optionTags.map((tag) {
+      // tag is ["option", "id", "label"]
+      if (tag.length >= 3) {
+        return PollOption(id: tag[1], label: tag[2]);
       }
       return null;
     }).whereType<PollOption>().toList();

--- a/lib/src/models/poll_response.dart
+++ b/lib/src/models/poll_response.dart
@@ -26,10 +26,10 @@ class PollResponse extends RegularModel<PollResponse> {
   /// For singlechoice polls, only the first response is considered valid.
   /// For multiplechoice polls, all unique response IDs are valid.
   Set<String> get selectedOptionIds {
-    final responseTags = event.getTagValues('response');
+    final responseTags = event.getTagSet('response');
     return responseTags
-        .where((values) => values.isNotEmpty)
-        .map((values) => values[0])
+        .where((tag) => tag.length >= 2)
+        .map((tag) => tag[1]) // tag is ["response", "option_id"]
         .toSet();
   }
 
@@ -48,10 +48,10 @@ mixin PartialPollResponseMixin on RegularPartialModel<PollResponse> {
   String? get pollId => event.getFirstTagValue('e');
 
   Set<String> get selectedOptionIds {
-    final responseTags = event.getTagValues('response');
+    final responseTags = event.getTagSet('response');
     return responseTags
-        .where((values) => values.isNotEmpty)
-        .map((values) => values[0])
+        .where((tag) => tag.length >= 2)
+        .map((tag) => tag[1]) // tag is ["response", "option_id"]
         .toSet();
   }
 

--- a/lib/src/models/poll_response.dart
+++ b/lib/src/models/poll_response.dart
@@ -1,0 +1,142 @@
+part of models;
+
+/// PollResponse represents a poll vote/response event (kind 1018) as specified in NIP-88.
+/// It contains the user's selected option(s) for a poll.
+class PollResponse extends RegularModel<PollResponse> {
+  late final BelongsTo<Poll> poll;
+
+  PollResponse.fromMap(super.map, super.ref) : super.fromMap() {
+    // Reference to the poll being responded to
+    poll = BelongsTo(
+      ref,
+      event.containsTag('e')
+          ? RequestFilter<Poll>(
+              ids: {event.getFirstTagValue('e')!},
+              kinds: {1068},
+            ).toRequest()
+          : null,
+    );
+  }
+
+  /// The poll event ID this response is for
+  String? get pollId => event.getFirstTagValue('e');
+
+  /// Selected option IDs from response tags
+  ///
+  /// For singlechoice polls, only the first response is considered valid.
+  /// For multiplechoice polls, all unique response IDs are valid.
+  Set<String> get selectedOptionIds {
+    final responseTags = event.getTagValues('response');
+    return responseTags
+        .where((values) => values.isNotEmpty)
+        .map((values) => values[0])
+        .toSet();
+  }
+
+  /// Get the first selected option (for singlechoice polls)
+  String? get selectedOptionId {
+    final responses = selectedOptionIds;
+    return responses.isEmpty ? null : responses.first;
+  }
+
+  /// The content field (usually empty for poll responses)
+  String get content => event.content;
+}
+
+/// Mixin for PartialPollResponse providing getters/setters
+mixin PartialPollResponseMixin on RegularPartialModel<PollResponse> {
+  String? get pollId => event.getFirstTagValue('e');
+
+  Set<String> get selectedOptionIds {
+    final responseTags = event.getTagValues('response');
+    return responseTags
+        .where((values) => values.isNotEmpty)
+        .map((values) => values[0])
+        .toSet();
+  }
+
+  /// Add a response (vote) for an option
+  void addResponse(String optionId) {
+    event.addTag('response', [optionId]);
+  }
+
+  /// Remove a response for an option
+  void removeResponse(String optionId) {
+    event.removeTagWithValue('response', optionId);
+  }
+
+  /// Clear all responses
+  void clearResponses() {
+    for (final optionId in selectedOptionIds) {
+      event.removeTagWithValue('response', optionId);
+    }
+  }
+}
+
+/// Create and sign new poll response events.
+///
+/// Example usage:
+/// ```dart
+/// // Single choice vote
+/// final vote = await PartialPollResponse(
+///   poll: pollEvent,
+///   selectedOptionIds: {'option_a'},
+/// ).signWith(signer);
+///
+/// // Multiple choice vote
+/// final multiVote = await PartialPollResponse(
+///   poll: pollEvent,
+///   selectedOptionIds: {'option_a', 'option_c'},
+/// ).signWith(signer);
+/// ```
+class PartialPollResponse extends RegularPartialModel<PollResponse>
+    with PartialPollResponseMixin {
+  PartialPollResponse.fromMap(super.map) : super.fromMap();
+
+  /// Creates a new poll response (vote)
+  ///
+  /// [poll] - The poll being voted on (required)
+  /// [selectedOptionIds] - Set of selected option IDs (required)
+  /// [createdAt] - Optional creation timestamp
+  PartialPollResponse({
+    required Poll poll,
+    required Set<String> selectedOptionIds,
+    DateTime? createdAt,
+  }) {
+    // Content is empty for poll responses per NIP-88
+    event.content = '';
+
+    if (createdAt != null) {
+      event.createdAt = createdAt;
+    }
+
+    // Reference the poll event
+    event.addTag('e', [poll.event.id]);
+
+    // Add response tags for each selected option
+    for (final optionId in selectedOptionIds) {
+      event.addTag('response', [optionId]);
+    }
+  }
+
+  /// Creates a poll response by poll ID (when you don't have the full Poll model)
+  PartialPollResponse.byPollId({
+    required String pollId,
+    required Set<String> selectedOptionIds,
+    DateTime? createdAt,
+  }) {
+    event.content = '';
+
+    if (createdAt != null) {
+      event.createdAt = createdAt;
+    }
+
+    // Reference the poll event by ID
+    event.addTag('e', [pollId]);
+
+    // Add response tags
+    for (final optionId in selectedOptionIds) {
+      event.addTag('response', [optionId]);
+    }
+  }
+}

--- a/lib/src/storage/storage.dart
+++ b/lib/src/storage/storage.dart
@@ -164,6 +164,17 @@ abstract class StorageNotifier extends StateNotifier<StorageState> {
       constructor: ShortFormPortraitVideo.fromMap,
       partialConstructor: PartialShortFormPortraitVideo.fromMap,
     );
+    // NIP-88: Polls
+    Model.register(
+      kind: 1018,
+      constructor: PollResponse.fromMap,
+      partialConstructor: PartialPollResponse.fromMap,
+    );
+    Model.register(
+      kind: 1068,
+      constructor: Poll.fromMap,
+      partialConstructor: PartialPoll.fromMap,
+    );
     Model.register(
       kind: 1063,
       constructor: FileMetadata.fromMap,


### PR DESCRIPTION
## Summary

Add NIP-88 poll support with two new model classes:

- **Poll** (kind:1068) - Poll events with question, options, poll type, and expiration
- **PollResponse** (kind:1018) - Vote/response events referencing a poll

## Changes

- `lib/src/models/poll.dart` - Poll model with PollOption, PollType, PartialPoll
- `lib/src/models/poll_response.dart` - PollResponse model with PartialPollResponse  
- `lib/src/storage/storage.dart` - Register kinds 1068 and 1018
- `lib/models.dart` - Export new models

## NIP-88 Specification

Per [NIP-88](https://github.com/nostr-protocol/nips/blob/master/88.md):

```
kind:1068 - Poll event
- content: poll question
- option tags: ["option", "<id>", "<label>"]
- polltype tag: "singlechoice" or "multiplechoice"
- endsAt tag: optional unix timestamp

kind:1018 - Poll response
- e tag: references poll event
- response tags: ["response", "<option_id>"]
```

## Usage

```dart
// Create a poll
final poll = PartialPoll(
  content: 'Which feature next?',
  options: [
    PollOption(id: 'a', label: 'Dark mode'),
    PollOption(id: 'b', label: 'Offline support'),
  ],
  pollType: PollType.singlechoice,
  endsAt: DateTime.now().add(Duration(days: 7)),
  targetModel: app,  // Link to an app via 'a' tag
);
final signedPoll = await poll.signWith(signer);

// Vote on a poll
final response = PartialPollResponse(
  poll: poll,
  selectedOptionIds: {'a'},
);
final signedResponse = await response.signWith(signer);
```

## Related

- zapstore PR: https://github.com/zapstore/zapstore/pull/294

Signed-off-by: alltheseas <alltheseas@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)